### PR TITLE
Configure Dependabot: 5am schedule + 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      time: "05:00"
+      timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "monthly"
     rebase-strategy: "auto"
+    schedule:
+      interval: "weekly"
+      time: "05:00"
+      timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
Aligns this repository's Dependabot config with the org standard (modeled on `feedbackfruits-api`):

- Runs at **05:00 Europe/Amsterdam**
- **7-day cooldown** on all updates (`cooldown.default-days: 7`; `semver-major-days: 14` on language ecosystems)
- Covers all package ecosystems detected in the repo
