### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           registry-url: https://npm.pkg.github.com
           node-version: ${{ env.NODE_VERSION }}
@@ -40,10 +40,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           registry-url: https://registry.npmjs.org
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
           cache: 'pnpm'
@@ -33,10 +33,10 @@ jobs:
         mongodb_driver_version: ['5.9.2', '6.21.0', 'latest']
         mongodb_version: ['7.0', '8.0']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
@@ -48,15 +48,15 @@ jobs:
         run: pnpm add -DE mongodb@${{ matrix.mongodb_driver_version }}; pnpm install
       - name: Compile app
         run: pnpm build
-      - uses: supercharge/mongodb-github-action@1.12.1
+      - uses: supercharge/mongodb-github-action@315db7fe45ac2880b7758f1933e6e5d59afd5e94 # 1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb_version }}
-      - uses: supercharge/redis-github-action@1.8.1
+      - uses: supercharge/redis-github-action@bc274cb7238cd63a45029db04ee48c07a72609fd # 1.8.1
       - name: Run tests
         run: pnpm test
         env:
           MONGODB_URI: mongodb://localhost:27017/east_mongo_test
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

Pins all `uses:` action references to full commit SHAs (with a version comment), per the [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses) audit from `zizmor`.

**Why:** mutable tag/branch refs (`@v4`) let a compromised or force-pushed tag silently run new code with this workflow's token. Pinning to an immutable SHA closes that supply-chain vector. Dependabot (already configured) will keep the SHAs updated.

No behavioral change — same action versions, just pinned. Files changed: release.yml test.yml .

🤖 Generated with [Claude Code](https://claude.com/claude-code)