### PR TITLE
Least-privilege permissions in release.yml (excessive-permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
       - master
 
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -17,6 +16,8 @@ jobs:
   release:
     name: Release (GH)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Enable Corepack
@@ -35,6 +36,9 @@ jobs:
   release-npm:
     name: Release (NPM)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Enable Corepack


### PR DESCRIPTION
## Apply least-privilege `permissions:`

Fixes the High-severity [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions) finding: a broad write permission is granted at the **workflow** level, so every job (including test jobs that run untrusted-ish code) gets a token that can push packages / mint OIDC identities.

**Fix:** default the workflow to `contents: read` and grant the elevated write **only to the specific job(s) that need it**.

⚠️ Please double-check the per-job scoping matches what each job actually needs before merging — I inferred it from the job steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @okv — flagging you as the recent contributor for review.