### PR TITLE
ci(zizmor): enforce high/high GitHub Actions security gate

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor GitHub Actions security analysis
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # needed for checkout on this private/internal repo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          min-severity: high
+          min-confidence: high


### PR DESCRIPTION
Adds the org-standard \`zizmor.yml\` workflow, gating GitHub Actions security findings at **high severity / high confidence** (per [`policies/zizmor.md`](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/policies/zizmor.md)).

- Runs on PRs (all branches) and push to the default branch.
- `advanced-security: false` → a high/high finding **fails the check** (fail-closed).
- Action steps SHA-pinned; least-privilege `permissions`.

Opened as **draft**: local offline scans are clean at high/high, but this workflow run also executes the online audits (known-vulnerable-actions, impostor-commit, ref-confusion, stale-action-refs). Will be marked ready once the check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)