### PR TITLE
fix(release): grant packages write to GH Packages publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Enable Corepack


### PR DESCRIPTION
Every run of the **Release (GH)** job fails with `403 Permission installation not allowed to Write organization package` — the job publishes to npm.pkg.github.com with the workflow `GITHUB_TOKEN`, but its permissions block only grants `contents: read`. This adds `packages: write` to that job (example failure: [run 30073294721](https://github.com/feedbackfruits/east-mongo/actions/runs/30073294721)).

Part of a set of release-pipeline fixes: together with #49 and #50; #51 should merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)