### PR TITLE
fix(release): skip publish when version is already on the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,19 @@ jobs:
         run: pnpm install
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+      - name: Check if version is already published
+        id: check
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "@feedbackfruits/east-mongo@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm publish
+        if: steps.check.outputs.published == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-npm:
@@ -52,4 +64,14 @@ jobs:
         run: pnpm install
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+      - name: Check if version is already published
+        id: check
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "@feedbackfruits/east-mongo@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm publish
+        if: steps.check.outputs.published == 'false'


### PR DESCRIPTION
The Release workflow runs on every push to master, so every merge that doesn't bump `package.json` version fails with `You cannot publish over the previously published versions: 2.0.0` — the workflow has been red on every Dependabot merge since 2.0.0 shipped in April. Both jobs now check the target registry first and skip `npm publish` when the current version already exists, so only actual version bumps publish and routine merges stay green.

If the version-exists check itself fails (e.g. no read access), it treats the version as unpublished and attempts the publish — no worse than today's behavior.

Part of a set of release-pipeline fixes: together with #48 and #50; #51 should merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)