### PR TITLE
fix(deps): move lint tooling to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mongodb": ">=5.7.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@feedbackfruits/eslint-config": "2.1.0",
     "@feedbackfruits/tsconfig": "2.0.1",
     "@types/jasmine": "6.0.0",
@@ -42,20 +43,17 @@
     "eslint": "10.6.0",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jasmine": "4.2.2",
+    "globals": "^17.4.0",
     "jasmine": "6.3.0",
     "jasmine-spec-reporter": "7.0.0",
     "mongodb": "7.5.0",
     "nyc": "18.0.0",
     "tsx": "4.23.1",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "typescript-eslint": "^8.57.2"
   },
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "dependencies": {
-    "@eslint/js": "^10.0.1",
-    "globals": "^17.4.0",
-    "typescript-eslint": "^8.57.2"
-  }
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,10 @@ overrides:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
-      globals:
-        specifier: ^17.4.0
-        version: 17.4.0
-      typescript-eslint:
-        specifier: ^8.57.2
-        version: 8.57.2(eslint@10.6.0)(typescript@5.9.3)
-    devDependencies:
       '@feedbackfruits/eslint-config':
         specifier: 2.1.0
         version: 2.1.0(@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0)(typescript@5.9.3))(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@5.9.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0))(eslint@10.6.0)
@@ -53,6 +46,9 @@ importers:
       eslint-plugin-jasmine:
         specifier: 4.2.2
         version: 4.2.2
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
       jasmine:
         specifier: 6.3.0
         version: 6.3.0
@@ -71,6 +67,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.57.2
+        version: 8.57.2(eslint@10.6.0)(typescript@5.9.3)
 
 packages:
 


### PR DESCRIPTION
`@eslint/js`, `globals`, and `typescript-eslint` were declared under runtime `dependencies` (and shipped that way in 2.0.0 on npm), so every consumer of this package installs eslint tooling. They're only used by `eslint.config.mjs` — moved to `devDependencies` and refreshed the lockfile. Build and lint verified locally.

Part of a set of release-pipeline fixes: together with #48 and #49; #51 should merge last so the published package picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)