### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@feedbackfruits/east-mongo",
   "description": "Mongodb adapter for east, the Node.js migration tool",
   "author": "FeedbackFruits <media@feedbackfruits.com>",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps the version to 2.0.1 so a release goes out on merge (the Release workflow publishes on push to master when the version isn't on the registry yet — no tags involved).

**Merge this last**, after #48, #49, and #50, so the published 2.0.1 includes the dependency fix and the publish jobs actually succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)