### PR TITLE
fix(deps): re-resolve js-yaml onto a patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,8 +1168,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1975,7 +1975,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -2934,7 +2934,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
### 💡 Summary

Moves `js-yaml` onto a patched version to close the Dependabot alerts below. The patched version already sits inside the range the manifests allow, so only the lockfile changes.

- [#46](https://github.com/feedbackfruits/east-mongo/security/dependabot/46) high — JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported (GHSA-5p4m-2wfm-xmqj), fixed in 3.15.1

Dependabot cannot open this PR. It bumps a transitive dependency only when it can bump the parent pinning it, so these alerts stay open even though the fix is published.

### 🛠️ What does this PR do?

- Re-resolves the lockfile with the repo's own package manager, limited to `js-yaml`.
- `audit` counts 11 actionable advisories before and 8 after. What remains belongs to other packages, each handled in its own PR.
- Touches no manifest, source, or workflow file. Had the re-resolve required one, this PR would not have been opened.

GitHub closes the alerts once this lands on `master`.

Generated by [`fix_lockfile.sh`](https://github.com/feedbackfruits/feedbackfruits-devsecops/blob/main/.claude/skills/dependabot-alert-audit/scripts/fix_lockfile.sh) in [feedbackfruits-devsecops](https://github.com/feedbackfruits/feedbackfruits-devsecops).
